### PR TITLE
🐛 Fix : 판매자 닉네임 오류 수정

### DIFF
--- a/book/serializers.py
+++ b/book/serializers.py
@@ -6,6 +6,9 @@ class BookSerializer(serializers.ModelSerializer):
 
     sale_condition_display = serializers.CharField(
         source='get_sale_condition_display', read_only=True)
+    writer_nickname = serializers.CharField(
+        source='writer.nickname', read_only=True)
+    
 
     class Meta:
         model = Book

--- a/book/views.py
+++ b/book/views.py
@@ -31,7 +31,7 @@ class BookListView(APIView, PaginationHandlerMixin):
     serializer_class = BookSerializer
 
     def get(self, request, *args, **kwargs):
-        booklist = Book.objects.all()
+        booklist = Book.objects.all().select_related('writer')
         page = self.paginate_queryset(booklist)
         if page is not None:
             serializer = self.get_paginated_response(


### PR DESCRIPTION
글 목록에 판매자 닉네임이 로그인한 사용자 닉네임으로 나오는 오류를 수정했습니다.
확인 부탁드립니다!